### PR TITLE
add  brackets after invoking of timeit function

### DIFF
--- a/train.py
+++ b/train.py
@@ -15,7 +15,7 @@ from tqdm import *
 import random
 from docopt import docopt
 import timeit
-start = timeit.timeit
+start = timeit.timeit()
 docstr = """Train ResNet-DeepLab on VOC12 (scenes) in pytorch using MSCOCO pretrained initialization 
 
 Usage: 
@@ -240,5 +240,5 @@ for iter in range(max_iter+1):
     if iter % 1000 == 0 and iter!=0:
         print 'taking snapshot ...'
         torch.save(model.state_dict(),'data/snapshots/VOC12_scenes_'+str(iter)+'.pth')
-end = timeit.timeit
+end = timeit.timeit()
 print end-start,'seconds'


### PR DESCRIPTION
According <https://docs.python.org/2/library/timeit.html#python-interface>, timeit.timeit is a function, we must add brackets after it, otherwise the error message `TypeError: unsupported operand type(s) for -: 'function' and 'function'` will appear at line 244